### PR TITLE
Spec file: Update upstream URL to avoid hacked website

### DIFF
--- a/ostree.spec
+++ b/ostree.spec
@@ -16,7 +16,7 @@ Release:	1
 Source0:	https://github.com/ostreedev/ostree/releases/download/v%{version}/libostree-%{version}.tar.xz
 Source1:	91-ostree.preset
 License:	LGPLv2+
-URL:		https://ostree.readthedocs.io/en/latest/
+URL:		https://ostreedev.github.io/ostree/
 
 BuildRequires:	git
 # We always run autogen.sh


### PR DESCRIPTION
Upstream's readthedocs website was hacked, we should use their new website.

For more details, see upstream issue ostreedev/ostree#3312